### PR TITLE
URL Cleanup

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,9 +22,9 @@ if (tasks.findByPath("artifactoryPublish")) {
 
 configure(allprojects) {
 	repositories {
-		maven { url "http://repo.springsource.org/libs-snapshot" }
-		maven { url "http://repo.springsource.org/libs-milestone" }
-		maven { url "http://repo.springsource.org/libs-release" }
+		maven { url "https://repo.springsource.org/libs-snapshot" }
+		maven { url "https://repo.springsource.org/libs-milestone" }
+		maven { url "https://repo.springsource.org/libs-release" }
 	}
 	group = 'scdf'
 }


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://repo.springsource.org/libs-milestone with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-milestone ([https](https://repo.springsource.org/libs-milestone) result 301).
* http://repo.springsource.org/libs-release with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-release ([https](https://repo.springsource.org/libs-release) result 301).
* http://repo.springsource.org/libs-snapshot with 1 occurrences migrated to:  
  https://repo.springsource.org/libs-snapshot ([https](https://repo.springsource.org/libs-snapshot) result 301).